### PR TITLE
Fix label_map for train_embert.py

### DIFF
--- a/embert/data_wrapper.py
+++ b/embert/data_wrapper.py
@@ -53,6 +53,8 @@ class DatasetWrapper(DataWrapper):
         self.split = split
         super().__init__(batch_size, max_seq_length, tokenizer, device)
 
+        self.label_map = {label: i for i, label in
+                          enumerate(processor.get_labels(), start=1)}
         examples = processor.get_examples(split)
         features = self.convert_examples_to_features(
             examples, max_seq_length)


### PR DESCRIPTION
Running train_embert.py fails with the missing declaration of `self._label_map`. Please accept this PR to solve the issue or fix it in your own way. Thank you! 